### PR TITLE
Fix Color Picker resource leak (#38122)

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
@@ -104,9 +104,10 @@ namespace ColorPicker.Mouse
             var rect = new Rectangle((int)mousePosition.X, (int)mousePosition.Y, 1, 1);
             using (var bmp = new Bitmap(rect.Width, rect.Height, PixelFormat.Format32bppArgb))
             {
-                var g = Graphics.FromImage(bmp);
-                g.CopyFromScreen(rect.Left, rect.Top, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
-
+                using (var g = Graphics.FromImage(bmp)) // Ensure Graphics object is disposed
+                {
+                    g.CopyFromScreen(rect.Left, rect.Top, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
+                }
                 return bmp.GetPixel(0, 0);
             }
         }


### PR DESCRIPTION
Added a using statement to properly dispose of the Graphics object created from the Bitmap. This fixes resource leak.

- [ ] **Closes:** #38122 + #24271?



